### PR TITLE
cleanup work

### DIFF
--- a/BasicRedisCacingExampleInDotNetCore/BasicRedisCacingExampleInDotNetCore.csproj
+++ b/BasicRedisCacingExampleInDotNetCore/BasicRedisCacingExampleInDotNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -6,8 +6,25 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0-preview.1.21103.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="ClientApp\dist\css\app.2549dc0b.css">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ClientApp\dist\favicon.ico">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ClientApp\dist\index.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ClientApp\dist\js\app.cd4e1a8d.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ClientApp\dist\js\chunk-vendors.da8f982a.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>

--- a/BasicRedisCacingExampleInDotNetCore/Models/GitResponseModel.cs
+++ b/BasicRedisCacingExampleInDotNetCore/Models/GitResponseModel.cs
@@ -1,107 +1,11 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace BasicRedisCacingExampleInDotNetCore.Models
 {
     public class GitResponseModel
     {
-        [JsonProperty("login")]
-        public string Login { get; set; }
 
-        [JsonProperty("id")]
-        public int Id { get; set; }
-
-        [JsonProperty("node_id")]
-        public string NodeId { get; set; }
-
-        [JsonProperty("avatar_url")]
-        public string AvatarUrl { get; set; }
-
-        [JsonProperty("gravatar_id")]
-        public string GravatarId { get; set; }
-
-        [JsonProperty("url")]
-        public string Url { get; set; }
-
-        [JsonProperty("html_url")]
-        public string HtmlUrl { get; set; }
-
-        [JsonProperty("followers_url")]
-        public string FollowersUrl { get; set; }
-
-        [JsonProperty("following_url")]
-        public string FollowingUrl { get; set; }
-
-        [JsonProperty("gists_url")]
-        public string GistsUrl { get; set; }
-
-        [JsonProperty("starred_url")]
-        public string StarredUrl { get; set; }
-
-        [JsonProperty("subscriptions_url")]
-        public string SubscriptionsUrl { get; set; }
-
-        [JsonProperty("organizations_url")]
-        public string OrganizationsUrl { get; set; }
-
-        [JsonProperty("repos_url")]
-        public string ReposUrl { get; set; }
-
-        [JsonProperty("events_url")]
-        public string EventsUrl { get; set; }
-
-        [JsonProperty("received_events_url")]
-        public string ReceivedEventsUrl { get; set; }
-
-        [JsonProperty("type")]
-        public string Type { get; set; }
-
-        [JsonProperty("site_admin")]
-        public bool SiteAdmin { get; set; }
-
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("company")]
-        public object Company { get; set; }
-
-        [JsonProperty("blog")]
-        public string Blog { get; set; }
-
-        [JsonProperty("location")]
-        public object Location { get; set; }
-
-        [JsonProperty("email")]
-        public string Email { get; set; }
-
-        [JsonProperty("hireable")]
-        public object Hireable { get; set; }
-
-        [JsonProperty("bio")]
-        public string Bio { get; set; }
-
-        [JsonProperty("twitter_username")]
-        public object TwitterUsername { get; set; }
-
-        [JsonProperty("public_repos")]
+        [JsonPropertyName("public_repos")]
         public int PublicRepos { get; set; }
-
-        [JsonProperty("public_gists")]
-        public int PublicGists { get; set; }
-
-        [JsonProperty("followers")]
-        public int Followers { get; set; }
-
-        [JsonProperty("following")]
-        public int Following { get; set; }
-
-        [JsonProperty("created_at")]
-        public DateTime CreatedAt { get; set; }
-
-        [JsonProperty("updated_at")]
-        public DateTime UpdatedAt { get; set; }
     }
 }

--- a/BasicRedisCacingExampleInDotNetCore/Models/ResponseModel.cs
+++ b/BasicRedisCacingExampleInDotNetCore/Models/ResponseModel.cs
@@ -1,20 +1,16 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace BasicRedisCacingExampleInDotNetCore.Models
 {
     public class ResponseModel
     {
-        [JsonProperty("username")]
+        [JsonPropertyName("username")]
         public string Username { get; set; }
 
-        [JsonProperty("repos")]
+        [JsonPropertyName("repos")]
         public string Repos { get; set; }
 
-        [JsonProperty("cached")]
+        [JsonPropertyName("cached")]
         public bool Cached { get; set; }
     }
 }

--- a/BasicRedisCacingExampleInDotNetCore/Startup.cs
+++ b/BasicRedisCacingExampleInDotNetCore/Startup.cs
@@ -1,15 +1,14 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using StackExchange.Redis;
 using System;
-using System.Diagnostics;
 using System.IO;
+using System.Net.Http;
 
 namespace BasicRedisCacingExampleInDotNetCore
 {
@@ -46,11 +45,11 @@ namespace BasicRedisCacingExampleInDotNetCore
             {
                 redisConnectionUrl = $"{redisHost}:{redisPort}";
             }
-
-            services.AddStackExchangeRedisCache(options =>
-            {
-                options.ConfigurationOptions = ConfigurationOptions.Parse(redisConnectionUrl);
-            });
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("dotnet");
+            client.BaseAddress = new Uri("https://api.github.com");
+            services.AddSingleton(client);
+            services.AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(redisConnectionUrl));
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)


### PR DESCRIPTION
I did a bit of refactoring to make this project a bit cleaner. Few items to highlight:

1. HttpClient should not be created & disposed of whenever you want to make a request, while they implement the dispose pattern they are not intended to be so temporally bounded. I added it as a DI'd singleton (a bit weird of a pattern but it seemed excessive to build a typed request object, figured that might be a bit confusing for folks)
2. The example was using a preview version of Microsoft's Caching extensions - which seemed out of place, I just replaced it with the default SE package
3. Mandated that the client distribution directory be copied to the output directory (this is really important if you're publishing this to azure)
4. Cleaned up import statements
5. Removed the nested `using` statements in the `ReposController` - Neither was really needed, you can get the object directly out of the request with the JSON extensions and as I mentioned earlier, the HttpClient should not be created & disposed
6. I removed the use of Newtonsoft, Newtonsoft was (probably still is to a large extent) the canonical JSON parser in .NET, but the Json Seralization stuff is now part of the framework and is allegedly quicker (same author AFAIK), so it's a rather large and unnecessary dependency for a project that we'd like to keep lightweight and terse, I modified the logic to handle the different parser.
7. I removed all the unnecessary fields from the `GitResponseModel` class - seemed unnecessary to have everything.
8. Some minor README cleanup
9. Changed the UserAgent from `chrome`->`dotnet`
10. properly named the keys along typical redis practices